### PR TITLE
Dependency update to the current state of Kotlin ecosystem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ hs_err_pid*
 ### Gradle template
 .gradle
 /build/
+alice/build
+sample/build
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/alice/build.gradle
+++ b/alice/build.gradle
@@ -4,10 +4,11 @@ apply plugin: 'kotlin'
 apply plugin: 'maven'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${core.kotlinVersion}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${core.kotlinVersion}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${core.kotlinCoroutinesVersion}"
 
-    compile "io.ktor:ktor-gson:${libs.ktor}"
-    compile "io.ktor:ktor-server-host-common:${libs.ktor}"
+    implementation "io.ktor:ktor-gson:${libs.ktor}"
+    implementation "io.ktor:ktor-server-host-common:${libs.ktor}"
 }
 
 install {

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
     ext {
         core = [
-                kotlinVersion: "1.2.31"
+                kotlinVersion: "1.3.50",
+                kotlinCoroutinesVersion: "1.3.2"
         ]
 
         libs = [
-                ktor  : "0.9.2",
+                ktor  : "1.2.5",
         ]
     }
 
@@ -23,7 +24,7 @@ apply plugin: 'kotlin'
 
 subprojects {
     group 'com.github.savinmike'
-    version '0.1'
+    version '0.1.1'
 
     repositories {
         mavenCentral()
@@ -31,7 +32,6 @@ subprojects {
         maven { url 'https://dl.bintray.com/kotlin/ktor' }
     }
 
-    kotlin { experimental { coroutines "enable" } }
 
     compileKotlin {
         kotlinOptions.jvmTarget = "1.8"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip

--- a/sample/src/main/kotlin/com/github/savinmike/alice/sample/BuyElephant.kt
+++ b/sample/src/main/kotlin/com/github/savinmike/alice/sample/BuyElephant.kt
@@ -10,7 +10,7 @@ import com.github.savinmike.alice.model.event.welcome
 import com.github.savinmike.alice.model.mapper.wrapToResponseData
 import io.ktor.server.netty.Netty
 
-fun main(args: Array<String>) {
+fun main() {
     val alice = alice {
         webhook = "alice-webhook"
         applicationEngineFactory = Netty


### PR DESCRIPTION
When one uses the library with modern Kotlin version it seas warning that experimental coroutines will be removed in 1.4 version of the language. Coroutines are in GA so no need of experimental flag any more.
Updated gradle wrapper to latest version so you can migrate to Gradle DSL further if you wish.
Updated kotlin, ktor and coroutines dependencies
fixed `.gitignore` to skil build folders of subprojects